### PR TITLE
fix path to desktop configuration (replace 'frameworks' by 'shared')

### DIFF
--- a/electron/main.desktop.ts
+++ b/electron/main.desktop.ts
@@ -13,7 +13,7 @@ let template: any;
 let menu: any;
 
 // app
-import { DesktopConfig } from 'frameworks/electron/index';
+import { DesktopConfig } from 'shared/electron/index';
 
 /*crashReporter.start({
   productName: 'Angular2WebpackAdvanceStarter',


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

fix issue #11


* **What is the current behavior?** (You can also link to an open issue here)

npm run start:desktop:windows fails.  The problem ppears to be wrong path in electron/main.desktop.ts:16, which is 'frameworks/electron/index' but in the new version should be 'shared/electron/index'.

* **What is the new behavior (if this is a feature change)?**

Builds and starts the electron app, although the app itself does not display.  But the bug that prevented successful build is fixed.

* **Other information**:
